### PR TITLE
Update download source URL

### DIFF
--- a/check/controller/installer.php
+++ b/check/controller/installer.php
@@ -327,7 +327,7 @@ class Installer
 		}
 
 		list($maj, $min, $bfx) = explode('.', $version);
-		$url = "http://sourceforge.net/projects/contao/files/$maj.$min/contao-$maj.$min.$bfx.zip/download";
+		$url = "http://download.contao.org/$maj.$min.$bfx/zip";
 
 		if ($this->php === false) {
 			if ($this->download == 'wget') {
@@ -340,7 +340,7 @@ class Installer
 			if (file_exists('download') && filesize('download') > 0) {
 				$this->exec($this->unzip . ' download');
 				$this->exec('rm download');
-				$folder = $this->exec('ls -d contao-*');
+				$folder = $this->exec('ls -d core-*');
 				$this->exec("mv $folder/* " . TL_ROOT . '/');
 				$this->exec("mv $folder/.[a-z]* " . TL_ROOT . '/'); // see #22
 				$this->exec("rm -rf $folder");
@@ -357,7 +357,7 @@ class Installer
 				unlink('download');
 			}
 
-			$glob = glob(TL_ROOT . '/contao-*');
+			$glob = glob(TL_ROOT . '/core-*');
 
 			// Remove the wrapper folder (see #23)
 			if (!empty($glob)) {

--- a/check/views/installer.phtml
+++ b/check/views/installer.phtml
@@ -29,7 +29,7 @@
       <?php if (!$this->isAvailable()): ?>
         <h3><?php echo _('Manual installation') ?></h3>
         <ul>
-          <li><?php printf(_('Go to %s and download the latest Contao version.'), '<a href="http://sourceforge.net/projects/contao/files/">sourceforge.net</a>') ?></li>
+          <li><?php printf(_('Go to %s and download the latest Contao version.'), '<a href="https://contao.org/download.html">contao.org</a>') ?></li>
           <li><?php echo _('Extract the download archive and upload the files to your server using an (S)FTP client.') ?></li>
           <li><?php echo _('Open the Contao install tool by adding "/contao" to the URL of your installation.') ?></li>
         </ul>


### PR DESCRIPTION
Since we recently [moved from SourceForge to GitHub](https://contao.org/en/news/final-migration-to-github.html), the web installer must be adjusted accordingly. That is, the current download link must point to the new URL.

Credit goes to @styxway who reported the issue.
