### PR TITLE
Utilize language label instead of showing "%s" in heading.

### DIFF
--- a/check/views/composer.phtml
+++ b/check/views/composer.phtml
@@ -12,7 +12,7 @@
     <h2><?php echo _('Composer package manager') ?></h2>
   </div>
   <div class="row">
-    <h3><?php echo _('PHP %s or greater') ?></h3>
+    <h3><?php echo printf(_('PHP %s or greater'), static::PHP_VERSION) ?></h3>
     <?php if ($this->hasPhp()): ?>
       <p class="confirm"><?php printf(_('You have PHP version %s.'), phpversion()) ?></p>
     <?php else: ?>


### PR DESCRIPTION
It stop showing "PHP %s or greater" in composer check.