### PR TITLE
add cURL check to util.php

### DIFF
--- a/check/includes/util.php
+++ b/check/includes/util.php
@@ -50,6 +50,10 @@ function function_disabled($func)
  */
 function curl($url)
 {
+	if (!function_exists('curl_init')) {
+		throw new RuntimeException('The installation package could not be downloaded: cURL is not available');
+	}
+
 	$ch = curl_init();
 
 	curl_setopt($ch, CURLOPT_HEADER, false);


### PR DESCRIPTION
While the availability for cURL is checked in the [composer controller](https://github.com/contao/check/blob/12.0/check/controller/composer.php#L91), it is not checked in the validator or installer controller which both make a call to `curl(…)` (of `util.php`) which in turn uses the `curl_…` functions. If cURL is not available, this will lead to a fatal error, e.g.
```
Fatal error: Call to undefined function curl_init() in /var/www/test/check/includes/util.php on line 53
```
This PR checks for the availability of the `curl_init` function within the `curl` function within `util.php` and throws a `RuntimeException` if not present. This will lead to the validator and installer to show that error (`The installation package could not be downloaded: cURL is not available`).