### PR TITLE
fix fclose error on failed connection

### DIFF
--- a/check/controller/installer.php
+++ b/check/controller/installer.php
@@ -110,10 +110,9 @@ class Installer
 	public function canConnect()
 	{
 		$connection = @fsockopen('ssl://download.contao.org', 443, $errno, $errstr, 10);
-		$connected = ($connection !== false);
-		fclose($connection);
 
-		if ($connected) {
+		if ($connection !== false) {
+			fclose($connection);
 			return true;
 		}
 

--- a/check/controller/live-update.php
+++ b/check/controller/live-update.php
@@ -194,10 +194,9 @@ class LiveUpdate
 	public function canConnect()
 	{
 		$connection = @fsockopen('ssl://update.contao.org', 443, $errno, $errstr, 10);
-		$connected = ($connection !== false);
-		fclose($connection);
 
-		if ($connected) {
+		if ($connection !== false) {
+			fclose($connection);
 			return true;
 		}
 

--- a/check/controller/repository.php
+++ b/check/controller/repository.php
@@ -76,10 +76,9 @@ class Repository
 	public function canConnect()
 	{
 		$connection = @fsockopen('ssl://contao.org', 443, $errno, $errstr, 10);
-		$connected = ($connection !== false);
-		fclose($connection);
 
-		if ($connected) {
+		if ($connection !== false) {
+			fclose($connection);
 			return true;
 		}
 


### PR DESCRIPTION
See https://github.com/contao/check/pull/107#issuecomment-290184167

I have simply moved `fclose` to the already existing `if ($connected)`.