### PR TITLE
add system temp dir check

### DIFF
--- a/check/controller/contao4.php
+++ b/check/controller/contao4.php
@@ -113,4 +113,20 @@ class Contao4
 
 		return false;
 	}
+
+	/**
+	 * Check whether the system tmp directory is writeable
+	 *
+	 * @return boolean True if the system tmp directory is writeable
+	 */
+	public function canWriteTmpDir()
+	{
+		if (is_writable(sys_get_temp_dir())) {
+			return true;
+		}
+
+		$this->compatible = false;
+
+		return false;
+	}
 }

--- a/check/controller/index.php
+++ b/check/controller/index.php
@@ -115,6 +115,10 @@ class Index
 			return false;
 		}
 
+		if (!$contao->canWriteTmpDir()) {
+			return false;
+		}
+
 		return true;
 	}
 

--- a/check/i18n/en.php
+++ b/check/i18n/en.php
@@ -186,5 +186,9 @@ return array(
 	'An unknown error occurred while getting the newest LTS version.' => 'An unknown error occurred while getting the newest LTS version.',
 	'Version file error' => 'Version file error',
 	'Error while retrieving version file: %s.' => 'Error while retrieving version file: %s.',
-	'There was an error retrieving the version file from contao.org for your Contao version.' => 'There was an error retrieving the version file from contao.org for your Contao version.'
+	'There was an error retrieving the version file from contao.org for your Contao version.' => 'There was an error retrieving the version file from contao.org for your Contao version.',
+	'System temp directory' => 'System temp directory',
+	'The system temp directory is writable.' => 'The system temp directory is writable.',
+	'The system temp directory is not writable.' => 'The system temp directory is not writable.',
+	'Make sure the correct directory is configured via the TMP, TMPDIR or TEMP environment variable or the sys_temp_dir PHP variable.' => 'Make sure the correct directory is configured via the TMP, TMPDIR or TEMP environment variable or the sys_temp_dir PHP variable.'
 );

--- a/check/views/contao4.phtml
+++ b/check/views/contao4.phtml
@@ -48,6 +48,15 @@
     <?php endif; ?>
   </div>
   <div class="row">
+    <h3><?php echo __('System temp directory') ?></h3>
+    <?php if ($this->canWriteTmpDir()): ?>
+      <p class="confirm"><?php echo __('The system temp directory is writable.') ?></p>
+    <?php else: ?>
+      <p class="error"><?php echo __('The system temp directory is not writable.') ?></p>
+      <p class="explain"><?php echo __('Make sure the correct directory is configured via the TMP, TMPDIR or TEMP environment variable or the sys_temp_dir PHP variable.') ?></p>
+    <?php endif; ?>
+  </div>
+  <div class="row">
     <?php if ($this->isCompatible()): ?>
       <p class="confirm large"><?php echo __('You can install Contao 4.x on this server.') ?></p>
     <?php else: ?>


### PR DESCRIPTION
During installation, Contao 4 uses `AbstractLockedCommand` for various commands. The `AbstractLockedCommand` creates a `LockHandler` instance without a second parameter [here](https://github.com/contao/core-bundle/blob/4.3.9/src/Command/AbstractLockedCommand.php#L30). This means the lock file will be written into the system temp directory (see [LockHandler.php#L42](https://github.com/symfony/symfony/blob/v3.2.8/src/Symfony/Component/Filesystem/LockHandler.php#L42)).

However, if the directory returned by `sys_get_temp_dir()` is not writable, the installation will fail with the following [error message](https://github.com/contao/core-bundle/blob/4.3.9/src/Command/AbstractLockedCommand.php#L33):
```
The command is already running in another process.
```
See also https://github.com/symfony/symfony/issues/20423.

This PR adds a check for Contao 4 whether the current system temp directory is writable or not.

Technically this may be necessary for Contao 3 as well, but I do not know under which circumstances. There is an old [german Wiki entry](http://de.contaowiki.org/Probleme_beim_Zugriff_auf_/tmp_mit_sys_get_temp_dir(),_tmpfile()_oder_tempnam()) for that particular problem.

![screen shot 2017-05-11 at 09 59 26](https://cloud.githubusercontent.com/assets/4970961/25938721/8a031eb4-3630-11e7-9ec7-0ff609f5fce1.png)

See also https://community.contao.org/de/showthread.php?64806-4-3-0-Installtool-will-nicht