### PR TITLE
Add robots tag noindex/nofollow to views

### DIFF
--- a/check/views/composer.phtml
+++ b/check/views/composer.phtml
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>Contao Check <?php echo CONTAO_CHECK_VERSION ?></title>
   <link rel="stylesheet" href="assets/style.css">
+  <meta name="robots" content="noindex, nofollow">
 </head>
 <body>
 <div id="wrapper">

--- a/check/views/contao2.phtml
+++ b/check/views/contao2.phtml
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>Contao Check <?php echo CONTAO_CHECK_VERSION ?></title>
   <link rel="stylesheet" href="assets/style.css">
+  <meta name="robots" content="noindex, nofollow">
 </head>
 <body>
 <div id="wrapper">

--- a/check/views/contao3.phtml
+++ b/check/views/contao3.phtml
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>Contao Check <?php echo CONTAO_CHECK_VERSION ?></title>
   <link rel="stylesheet" href="assets/style.css">
+  <meta name="robots" content="noindex, nofollow">
 </head>
 <body>
 <div id="wrapper">

--- a/check/views/contao4.phtml
+++ b/check/views/contao4.phtml
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>Contao Check <?php echo CONTAO_CHECK_VERSION ?></title>
   <link rel="stylesheet" href="assets/style.css">
+  <meta name="robots" content="noindex, nofollow">
 </head>
 <body>
 <div id="wrapper">

--- a/check/views/file-permissions.phtml
+++ b/check/views/file-permissions.phtml
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>Contao Check <?php echo CONTAO_CHECK_VERSION ?></title>
   <link rel="stylesheet" href="assets/style.css">
+  <meta name="robots" content="noindex, nofollow">
 </head>
 <body>
 <div id="wrapper">

--- a/check/views/index.phtml
+++ b/check/views/index.phtml
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>Contao Check <?php echo CONTAO_CHECK_VERSION ?></title>
   <link rel="stylesheet" href="assets/style.css">
+  <meta name="robots" content="noindex, nofollow">
 </head>
 <body>
 <div id="wrapper">

--- a/check/views/installer.phtml
+++ b/check/views/installer.phtml
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>Contao Check <?php echo CONTAO_CHECK_VERSION ?></title>
   <link rel="stylesheet" href="assets/style.css">
+  <meta name="robots" content="noindex, nofollow">
 </head>
 <body>
 <div id="wrapper">

--- a/check/views/live-update.phtml
+++ b/check/views/live-update.phtml
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>Contao Check <?php echo CONTAO_CHECK_VERSION ?></title>
   <link rel="stylesheet" href="assets/style.css">
+  <meta name="robots" content="noindex, nofollow">
 </head>
 <body>
 <div id="wrapper">

--- a/check/views/repository.phtml
+++ b/check/views/repository.phtml
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>Contao Check <?php echo CONTAO_CHECK_VERSION ?></title>
   <link rel="stylesheet" href="assets/style.css">
+  <meta name="robots" content="noindex, nofollow">
 </head>
 <body>
 <div id="wrapper">

--- a/check/views/validator.phtml
+++ b/check/views/validator.phtml
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>Contao Check <?php echo CONTAO_CHECK_VERSION ?></title>
   <link rel="stylesheet" href="assets/style.css">
+  <meta name="robots" content="noindex, nofollow">
 </head>
 <body>
 <div id="wrapper">


### PR DESCRIPTION
The contao/check works even if contao isn't installed yet.
This means the robots.txt from the contao/core may not be available after installing contao/check.

As I don't want to find a contao/check installation in my google results we should ask search engines not to index this script.