### PR TITLE
turn off URL rewriting

### DIFF
--- a/check/.htaccess
+++ b/check/.htaccess
@@ -1,0 +1,4 @@
+<IfModule mod_rewrite.c>
+    # Turn off any rewrites from parent folders
+    RewriteEngine Off
+</IfModule>


### PR DESCRIPTION
If Contao 4 is used and you put the Contao Check in the `/web` folder to check the server environment for example, you cannot access the Contao Check via `https://example.org/check/` due to the URL rewriting of the `/web/.htaccess`.